### PR TITLE
Fix leaderboard return types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# What's Here
+
+Replace this with a brief description of what this PR accomplishes.
+
+## Where to Start
+
+Optional section to help guide the reviewer in a larger PR. Feel free to remove for small or self-evident PRs.
+
+## Gotchas or Learnings
+
+Optional section to call out anything revelatory or revolutionary. Feel free to remove for small or self-evident PRs.
+
+## Related Issues
+
+{Issue Number Here}
+
+## Related PRs
+
+Mention any PRs in this repo by `#` link or link to relevant changes in other repos {PR Number Here}
+
+## What's Next
+
+Any further work related to this ticket, or links to related tickets. If nothing, please specify **N/A**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@diamondkinetics/ng-dk-public-service",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.2.3",
@@ -17,7 +17,7 @@
         "@angular/platform-browser": "^17.2.3",
         "@angular/platform-browser-dynamic": "^17.2.3",
         "@angular/router": "^17.2.3",
-        "@diamondkinetics/dk-public-dto-ts": "^0.8.4",
+        "@diamondkinetics/dk-public-dto-ts": "^1.0.0",
         "rxjs": "^6.6.7",
         "tslib": "^2.6.2",
         "zone.js": "~0.14.4"
@@ -3621,9 +3621,9 @@
       }
     },
     "node_modules/@diamondkinetics/dk-public-dto-ts": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@diamondkinetics/dk-public-dto-ts/-/dk-public-dto-ts-0.8.4.tgz",
-      "integrity": "sha512-QPFHJ0gUNbgl1KGVcvmVpS7hSNoIazAIfAbMWK87LPq/8OEI0BKVYq4L/VKOKZOS08PyfcDmAc4Mwspo3tv1FQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@diamondkinetics/dk-public-dto-ts/-/dk-public-dto-ts-1.0.2.tgz",
+      "integrity": "sha512-NbnWVr5/5MK8M5u8NCnC3IBm2uDJq2g2Xcw3+2zQBfQrw8cPkurPRWtfgC9/JZlhMAZMv3L77SIMgTG2lyteRw==",
       "engines": {
         "node": ">=8.9"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
   "description": "An Angular library with services for integrating with the Diamond Kinetics public API.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": "https://github.com/diamondkinetics/ng-dk-public-service",
   "license": "MIT",
   "scripts": {

--- a/projects/ng-dk-public-service/package.json
+++ b/projects/ng-dk-public-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
   "description": "An Angular library with services for integrating with the Diamond Kinetics public API.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": "https://github.com/diamondkinetics/ng-dk-public-service",
   "license": "MIT",
   "peerDependencies": {

--- a/projects/ng-dk-public-service/src/lib/service/http/v2/leaderboard/leaderboard.service.v2.ts
+++ b/projects/ng-dk-public-service/src/lib/service/http/v2/leaderboard/leaderboard.service.v2.ts
@@ -8,24 +8,23 @@ import { ResourceMapping as route } from '../../../../enum/resource-mapping.enum
 
 @Injectable({ providedIn: 'root' })
 export class LeaderboardServiceV2 extends AbstractResourceService<LeaderboardDTOV2> {
+  constructor(protected http: HttpClient) {
+    super(http, 2, route.LEADERBOARDS.getPath());
+  }
 
-	constructor(protected http: HttpClient) {
-		super(http, 2, route.LEADERBOARDS.getPath())
-	}
+  public getForGroup(groupUuid: string): Observable<LeaderboardDTOV2[]> {
+    return this.http.get<LeaderboardDTOV2[]>(
+      `/${this.getVersionString()}/${route.GROUPS}/${groupUuid}/${route.LEADERBOARDS}`
+    );
+  }
 
-	public getForGroup(groupUuid: string): Observable<LeaderboardDTOV2> {
-		return this.http.get<LeaderboardDTOV2>(
-			`/${this.getVersionString()}/${route.GROUPS}/${groupUuid}/${route.LEADERBOARDS}`);
-	}
+  public getResults(uuid: string): Observable<LeaderboardResultDTOV2[]> {
+    return this.http.get<LeaderboardResultDTOV2[]>(`/${this.getVersionString()}/${route.LEADERBOARDS}/${uuid}/results`);
+  }
 
-	public getResults(uuid: string): Observable<LeaderboardResultDTOV2> {
-		return this.http.get<LeaderboardResultDTOV2>(
-			`/${this.getVersionString()}/${route.LEADERBOARDS}/${uuid}/results`);
-	}
-
-	public getResultsForUser(userUuid: string): Observable<LeaderboardResultDTOV2> {
-		return this.http.get<LeaderboardResultDTOV2>(
-			`/${this.getVersionString()}/${route.USERS}/${userUuid}/${route.LEADERBOARDS}`);
-	}
-
+  public getResultsForUser(userUuid: string): Observable<LeaderboardResultDTOV2[]> {
+    return this.http.get<LeaderboardResultDTOV2[]>(
+      `/${this.getVersionString()}/${route.USERS}/${userUuid}/${route.LEADERBOARDS}`
+    );
+  }
 }


### PR DESCRIPTION
In our V2 leaderboard service, some of the functions that are supposed to be retrieving collections of leaderboards or leaderboard results are not specifying the correct return type. For a long time they've been returning observables of a single object, but the web app never seemed to care and didn't have a problem turning them into collections.

Now that the leaderboard state is being migrated to an NgRx feature in the web app, the code no longer like the types being returned by the leaderboard service.

This updates the functions that are supposed to return collections to do so.