### PR TITLE
Add support for V6 ViewSection integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
   "description": "An Angular library with services for integrating with the Diamond Kinetics public API.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": "https://github.com/diamondkinetics/ng-dk-public-service",
   "license": "MIT",
   "scripts": {

--- a/projects/ng-dk-public-service/package.json
+++ b/projects/ng-dk-public-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
   "description": "An Angular library with services for integrating with the Diamond Kinetics public API.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": "https://github.com/diamondkinetics/ng-dk-public-service",
   "license": "MIT",
   "peerDependencies": {

--- a/projects/ng-dk-public-service/src/lib/enum/resource-mapping.enum.ts
+++ b/projects/ng-dk-public-service/src/lib/enum/resource-mapping.enum.ts
@@ -40,6 +40,7 @@ export class ResourceMapping {
   public static readonly CARD_DESIGNS = new ResourceMapping('cardDesigns');
   public static readonly ACTIVITY_DEFINITIONS = new ResourceMapping('activityDefinitions');
   public static readonly INVITE = new ResourceMapping('invite');
+  public static readonly VIEW_SECTIONS = new ResourceMapping('viewSections');
 
   constructor(private readonly path: string) {}
 

--- a/projects/ng-dk-public-service/src/lib/service/http/v6/service-v6.module.ts
+++ b/projects/ng-dk-public-service/src/lib/service/http/v6/service-v6.module.ts
@@ -15,6 +15,7 @@ import { ChallengeProgressV6Module } from './challenge-progress/challenge-progre
 import { UserToUserConnectionV6Module } from './user-to-user-connection/user-to-user-connection-v6.module';
 import { UserActivityV6Module } from './user-activity/user-activity-v6.module';
 import { ActivityDefinitionV6Module } from './activity-definition/activity-definition-v6.module';
+import { ViewSectionV6Module } from './view-section/view-section-v6.module';
 
 @NgModule({
   imports: [CommonModule],
@@ -34,6 +35,7 @@ import { ActivityDefinitionV6Module } from './activity-definition/activity-defin
     UserToUserConnectionV6Module,
     UserActivityV6Module,
     ActivityDefinitionV6Module,
+    ViewSectionV6Module
   ],
 })
 export class ServiceV6Module {

--- a/projects/ng-dk-public-service/src/lib/service/http/v6/view-section/view-section-v6.module.ts
+++ b/projects/ng-dk-public-service/src/lib/service/http/v6/view-section/view-section-v6.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { ModuleWithProviders, NgModule, Optional, SkipSelf } from '@angular/core';
+import { ViewSectionV6Service } from './view-section-v6.service';
+
+@NgModule({
+  imports: [CommonModule],
+})
+export class ViewSectionV6Module {
+  constructor(@Optional() @SkipSelf() parentModule: ViewSectionV6Module) {
+    if (parentModule) {
+      throw new Error('ViewSectionV6Module is already loaded. Import it in ServiceModuleV6 only.');
+    }
+  }
+
+  static forRoot(): ModuleWithProviders<ViewSectionV6Module> {
+    return {
+      ngModule: ViewSectionV6Module,
+      providers: [ViewSectionV6Service],
+    };
+  }
+}

--- a/projects/ng-dk-public-service/src/lib/service/http/v6/view-section/view-section-v6.service.ts
+++ b/projects/ng-dk-public-service/src/lib/service/http/v6/view-section/view-section-v6.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { ViewSectionCollectionResponseV6, ViewSectionResponseV6 } from '@diamondkinetics/dk-public-dto-ts';
+import { Observable } from 'rxjs';
+import { AbstractRequestResponseResourceService } from '../../abstract-request-response-resource.service';
+import { ResourceMapping } from '../../../../enum/resource-mapping.enum';
+
+@Injectable({ providedIn: 'root' })
+export class ViewSectionV6Service extends AbstractRequestResponseResourceService<
+  void,
+  void,
+  ViewSectionResponseV6,
+  ViewSectionCollectionResponseV6
+> {
+  constructor(protected httpClient: HttpClient) {
+    super(httpClient, 6, ResourceMapping.VIEW_SECTIONS.getPath());
+  }
+
+  public getForActivityDefinition(
+    activityDefinitionUuid: string,
+    page = 0,
+    size = 20,
+    sortBy = 'serverCreated',
+    sortDirection = 'desc',
+    params = {}
+  ): Observable<ViewSectionCollectionResponseV6> {
+    const pagingParams = { page, size, sort: `${sortBy},${sortDirection}` };
+    params = { ...params, ...pagingParams };
+
+    return this.httpClient.get<ViewSectionCollectionResponseV6>(
+      `/v${this.versionNumber}/${ResourceMapping.ACTIVITY_DEFINITIONS}/${activityDefinitionUuid}/${ResourceMapping.VIEW_SECTIONS}`,
+      { params }
+    );
+  }
+}

--- a/projects/ng-dk-public-service/src/public-api.ts
+++ b/projects/ng-dk-public-service/src/public-api.ts
@@ -49,6 +49,8 @@ export { UserActivityV6Module } from './lib/service/http/v6/user-activity/user-a
 export { UserActivityV6Service } from './lib/service/http/v6/user-activity/user-activity-v6.service';
 export { ActivityDefinitionV6Module } from './lib/service/http/v6/activity-definition/activity-definition-v6.module';
 export { ActivityDefinitionV6Service } from './lib/service/http/v6/activity-definition/activity-definition-v6.service';
+export { ViewSectionV6Module } from './lib/service/http/v6/view-section/view-section-v6.module';
+export { ViewSectionV6Service } from './lib/service/http/v6/view-section/view-section-v6.service';
 
 /////////////////////////////////////////////////////////////////////////////////////
 //                                      V4


### PR DESCRIPTION
# What's Here

This adds a V6 ViewSection integration that will support the recommended activities portion of the Challenges V2 effort. There's an open PR in the API repo that will add the endpoint that is going to be used for fetching ViewSection objects for a specific activity definition.
