### PR TITLE
URI string fix in the V6 pitch service

### DIFF
--- a/projects/ng-dk-public-service/package.json
+++ b/projects/ng-dk-public-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
   "description": "An Angular library with services for integrating with the Diamond Kinetics public API.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": "https://github.com/diamondkinetics/ng-dk-public-service",
   "license": "MIT",
   "peerDependencies": {

--- a/projects/ng-dk-public-service/src/lib/service/http/v6/pitch/pitch-v6.service.ts
+++ b/projects/ng-dk-public-service/src/lib/service/http/v6/pitch/pitch-v6.service.ts
@@ -13,7 +13,7 @@ export class PitchV6Service extends AbstractRequestResponseResourceService<
   PitchCollectionResponseV6
 > {
   constructor(protected httpClient: HttpClient) {
-    super(httpClient, 6, ResourceMapping.SWINGS.getPath());
+    super(httpClient, 6, ResourceMapping.PITCHES.getPath());
   }
 
   public listForPitchingSession(


### PR DESCRIPTION
# What's Here

Fixes the use of an incorrect string in the v6 pitch service that is used to construct the request URI.
