### PR TITLE
Fix broken tests from Angular 19 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
   "description": "An Angular library with services for integrating with the Diamond Kinetics public API.",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "repository": "https://github.com/diamondkinetics/ng-dk-public-service",
   "license": "MIT",
   "scripts": {

--- a/projects/ng-dk-public-service/package.json
+++ b/projects/ng-dk-public-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diamondkinetics/ng-dk-public-service",
   "description": "An Angular library with services for integrating with the Diamond Kinetics public API.",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "repository": "https://github.com/diamondkinetics/ng-dk-public-service",
   "license": "MIT",
   "peerDependencies": {

--- a/projects/ng-dk-public-service/src/test/service/http/resource.service.test-suite.spec.ts
+++ b/projects/ng-dk-public-service/src/test/service/http/resource.service.test-suite.spec.ts
@@ -40,7 +40,7 @@ export abstract class ResourceServiceTestSuite<T extends AbstractSyncableDTO, S 
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [],
-        providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+        providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting(), ...this.providers],
       });
 
       this.httpTestingController = TestBed.inject(HttpTestingController);


### PR DESCRIPTION
# What's Here

This fixes an issue where tests broke due to an Angular schematic wiping out our request interceptor provider as a result of the v19 upgrade process.
